### PR TITLE
TRUS-4423 [CS] update autocomplete on address comps

### DIFF
--- a/app/views/components/InternationalAddress.scala.html
+++ b/app/views/components/InternationalAddress.scala.html
@@ -58,7 +58,7 @@ countryOptions: Seq[InputOption]
  field = form("line3"),
  label = messages("site.address.nonUk.line3"),
  inputClass = Some("govuk-!-width-two-thirds"),
- autocomplete = Some("address-line3")
+ autocomplete = Some("address-level2")
 )
 
 @select(

--- a/app/views/components/UKAddress.scala.html
+++ b/app/views/components/UKAddress.scala.html
@@ -52,14 +52,14 @@ govukFieldset: GovukFieldset
     @input_text(
         field = form("line3"),
         label = messages("site.address.uk.line3"),
-        autocomplete = Some("address-level2"),
+        autocomplete = Some("address-line3"),
         inputClass = Some("govuk-!-width-two-thirds")
     )
 
     @input_text(
         field = form("line4"),
         label = messages("site.address.uk.line4"),
-        autocomplete = Some("address-county"),
+        autocomplete = Some("address-level2"),
         inputClass = Some("govuk-!-width-two-thirds")
     )
 

--- a/app/views/components/UKAddress.scala.html
+++ b/app/views/components/UKAddress.scala.html
@@ -38,37 +38,36 @@ govukFieldset: GovukFieldset
 
 @html = {
     @input_text(
-    field = form("line1"),
-    label = messages("site.address.uk.line1"),
-    autocomplete = Some("address-line1")
-)
+        field = form("line1"),
+        label = messages("site.address.uk.line1"),
+        autocomplete = Some("address-line1")
+    )
 
-@input_text(
-    field = form("line2"),
-    label = messages("site.address.uk.line2"),
-    autocomplete = Some("address-line2")
-)
+    @input_text(
+        field = form("line2"),
+        label = messages("site.address.uk.line2"),
+        autocomplete = Some("address-line2")
+    )
 
-@input_text(
-    field = form("line3"),
-    label = messages("site.address.uk.line3"),
-    inputClass = Some("govuk-!-width-two-thirds"),
-    autocomplete = Some("address-line3")
+    @input_text(
+        field = form("line3"),
+        label = messages("site.address.uk.line3"),
+        autocomplete = Some("address-level2"),
+        inputClass = Some("govuk-!-width-two-thirds")
+    )
 
-)
+    @input_text(
+        field = form("line4"),
+        label = messages("site.address.uk.line4"),
+        autocomplete = Some("address-county"),
+        inputClass = Some("govuk-!-width-two-thirds")
+    )
 
-@input_text(
-    field = form("line4"),
-    label = messages("site.address.uk.line4"),
-    inputClass = Some("govuk-!-width-two-thirds"),
-    autocomplete = Some("address-level4")
-)
-
-@input_text(
-    field = form("postcode"),
-    label = messages("site.address.uk.postcode"),
-    hint = Some(messages(s"site.address.uk.postcode.hint")),
-    inputClass = Some("govuk-input--width-10"),
-    autocomplete = Some("postal-code")
-)
+    @input_text(
+        field = form("postcode"),
+        label = messages("site.address.uk.postcode"),
+        autocomplete = Some("postal-code"),
+        hint = Some(messages(s"site.address.uk.postcode.hint")),
+        inputClass = Some("govuk-input--width-10")
+    )
 }


### PR DESCRIPTION
`address-level4` has been replaced with `address-level2`

for international address `address-line3` has been replaced with `address-level2`

UK manual address reference within HMRC
https://github.com/hmrc/identity-verification-frontend/blob/master/app/uk/gov/hmrc/identityverification/journey/callcredit/views/enter_address_manual.scala.html

Docs on address levels for reference - UK address levels typically only level1 or level2
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-address-level4

https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#more-on-address-levels

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#administrative_levels_in_addresses