### PR TITLE
DDCE-2441 - Update for img-src and analytics

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,12 +54,12 @@ play.filters.csp {
         base-uri = "'self'"
         block-all-mixed-content = ""
         child-src = "'none'"
-        connect-src = "'self' https://www.google-analytics.com"
+        connect-src = "'self' https://www.google-analytics.com https://stats.g.doubleclick.net"
         default-src = "'none'"
         frame-ancestors = "'self'"
-        img-src = "'self'"
-        font-src = "'self'"
-        script-src = ${play.filters.csp.nonce.pattern} "'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://tagmanager.google.com https://fonts.googleapis.com"
+        img-src = "'self' https://stats.g.doubleclick.net  https://www.google-analytics.com https://tagmanager.google.com  ssl.gstatic.com www.gstatic.com"
+        font-src = "'self' https://fonts.gstatic.com"
+        script-src = ${play.filters.csp.nonce.pattern} "'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.google-analytics.com https://tagmanager.google.com https://fonts.googleapis.com stats.g.doubleclick.net"
         style-src = ${play.filters.csp.nonce.pattern} "'self' localhost:9793 localhost:9250 localhost:12345 https://tagmanager.google.com https://fonts.googleapis.com"
     }
 }


### PR DESCRIPTION
DDCE-2441 - Update for img-src and analytics

Used [this link](https://csplite.com/csp/svc/?pl=eJxNjt0KwjAMhd8l90I359DTd%2FAdQlsh0LXQFkXG3t2GCnqV5OP8hHHFXrGCHhJbKGQrDEjHDBJPlvuyC9ZBciIrmMztdx4VF1DKyQWy986nBVRbEddO%2Fp14Ezd4V8XwDFETZtX1opdE77j4ev56%2F9kymD6Xy8ZNjcYeH8MlNkU%3D#CSP_rules) as a guide to add extra csp for google analytics