### PR TITLE
DDCE-2241 - add https://www.google.com/ads/ga-audiences to img-src

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -57,7 +57,7 @@ play.filters.csp {
         connect-src = "'self' https://www.google-analytics.com https://stats.g.doubleclick.net"
         default-src = "'none'"
         frame-ancestors = "'self'"
-        img-src = "'self' https://stats.g.doubleclick.net  https://www.google-analytics.com https://tagmanager.google.com  ssl.gstatic.com www.gstatic.com"
+        img-src = "'self' https://stats.g.doubleclick.net  https://www.google-analytics.com https://tagmanager.google.com  ssl.gstatic.com www.gstatic.com https://www.google.com/ads/ga-audiences"
         font-src = "'self' https://fonts.gstatic.com"
         script-src = ${play.filters.csp.nonce.pattern} "'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.google-analytics.com https://tagmanager.google.com https://fonts.googleapis.com stats.g.doubleclick.net"
         style-src = ${play.filters.csp.nonce.pattern} "'self' localhost:9793 localhost:9250 localhost:12345 https://tagmanager.google.com https://fonts.googleapis.com"


### PR DESCRIPTION

Stop this console log from occurring. This was missed from the last PR, it was in the list of img-src from the [reference](https://csplite.com/csp/svc/?pl=eJxNjt0KwjAMhd8l90I359DTd%2FAdQlsh0LXQFkXG3t2GCnqV5OP8hHHFXrGCHhJbKGQrDEjHDBJPlvuyC9ZBciIrmMztdx4VF1DKyQWy986nBVRbEddO%2Fp14Ezd4V8XwDFETZtX1opdE77j4ev56%2F9kymD6Xy8ZNjcYeH8MlNkU%3D#CSP_rules).
``` bash
Refused to load the image 'https://www.google.com/ads/ga-audiences?
t=sr&aip=1&_r=4&slf_rd=1&v=1&_v=j96&tid=UA-43414424-
3&cid=438343197.1646739496&jid=14627239&_u=SACAAEABAAAAAC~&z=803149578' because it 
violates the following Content Security Policy directive: "img-src 'self' https://stats.g.doubleclick.net 
https://www.google-analytics.com https://tagmanager.google.com  ssl.gstatic.com www.gstatic.com".
```