### PR TITLE
DDCE-6950 - BootstrapVersion and MongoVersion updated to 9.18.0 & 2.7.0 resp

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,8 +2,8 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.13.0"
-  private val mongoVersion = "2.6.0"
+  private val bootstrapVersion = "9.18.0"
+  private val mongoVersion = "2.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                     % mongoVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework"    % "sbt-plugin"            % "3.0.7")
+addSbtPlugin("org.playframework"    % "sbt-plugin"            % "3.0.8")
 addSbtPlugin("org.scalastyle"      %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 addSbtPlugin("org.scoverage"        % "sbt-scoverage"         % "2.3.1")
 addSbtPlugin("io.github.irundaia"   % "sbt-sassify"           % "1.5.2")


### PR DESCRIPTION
DDCE-6950 - BootstrapVersion and MongoVersion updated to 9.18.0 & 2.7.0 respectively
<img width="1915" height="1197" alt="image" src="https://github.com/user-attachments/assets/700e3b8d-c6d2-4244-b6e9-6119d55f7752" />
